### PR TITLE
update anchor UI to use mrklt 0.2.0 for speed increase

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "graphql-tag": "^2.11.0",
     "hash-wasm": "^4.3.0",
     "is-extglob": "^2.1.1",
-    "mrklt": "^0.1.0",
+    "mrklt": "^0.2.0",
     "react-apollo": "^3.1.5"
   }
 }

--- a/packages/apps-routing/src/index.ts
+++ b/packages/apps-routing/src/index.ts
@@ -14,7 +14,7 @@ import democracy from './democracy';
 import explorer from './explorer';
 import extrinsics from './extrinsics';
 import masterSubmission from './master-proposals';
-// import anchor from './anchor';
+import anchor from './anchor';
 import genericAsset from './generic-asset';
 import js from './js';
 import parachains from './parachains';
@@ -52,7 +52,7 @@ export default function create (t: <T = string> (key: string, text: string, opti
     storage(t),
     extrinsics(t),
     masterSubmission(t),
-    // anchor(t),
+    anchor(t),
     rpc(t),
     signing(t),
     sudo(t),

--- a/packages/page-anchor/src/Check.tsx
+++ b/packages/page-anchor/src/Check.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { ProofElement, dehexproof } from './hrproof';
-import { blake2sFile, blake2b256 } from './hash';
+import { blake2b256File, blake2b256 } from './hash';
 import { u8aToHex } from '@polkadot/util';
 import { useApi } from '@polkadot/react-hooks';
 import ApiPromise from '@polkadot/api/promise';
@@ -21,12 +21,6 @@ type AnchorStatus = {
   tag: 'hashing',
 };
 
-/* function depends<T, R>(compute: (_: T) => Promise<R>, dat: T, initial: R): R {
- *   const [ret, setRet] = useState<R>(initial);
- *   useEffect(() => { compute(dat).then(setRet); }, [dat]);
- *   return ret;
- * }
- *  */
 function Check(): React.ReactElement {
   const [file, setFile] = useState<File | null>(null);
   const [proofFile, setProofFile] = useState<File | null>(null);
@@ -51,7 +45,7 @@ function Check(): React.ReactElement {
     if (file === null) { return; }
 
     setAnchorStatus({ tag: 'hashing' });
-    const fileHash = await blake2sFile(file);
+    const fileHash = await blake2b256File(file);
 
     const proof = proofFile === null ? [] : await proofFromFile(proofFile);
     const root = await vproof(fileHash, proof);

--- a/tsfmt.json
+++ b/tsfmt.json
@@ -1,0 +1,3 @@
+{
+  "indentSize": 2
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17261,10 +17261,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mrklt@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "mrklt@npm:0.1.0"
-  checksum: 251961fa2afd8b9a820368cb6f7cd549a19a2a44d0dfd36cb0a92191e9ec4bb33181ae7bc57e8fdc296a8d3101f782dd90921ac200e9a9ef2e5dab66865350ed
+"mrklt@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "mrklt@npm:0.2.0"
+  checksum: 5ca116d7d77c6bc2d332ba125489bb029756bfbd3adf0499c3a65dab5b6383421a4f4fbcc96c05761d6eb14107f06d3eb08811d74a2986b97714e7a1b308f0da
   languageName: node
   linkType: hard
 
@@ -19058,7 +19058,7 @@ fsevents@^1.2.7:
     hash-wasm: ^4.3.0
     i18next-scanner: ^2.11.0
     is-extglob: ^2.1.1
-    mrklt: ^0.1.0
+    mrklt: ^0.2.0
     react: ^16.13.1
     react-apollo: ^3.1.5
     react-dom: ^16.13.1


### PR DESCRIPTION
The new code uses the "all in one" proof generation feature introduced in docknetwork/mrklt#5 .
The hasher used in the mrklt 0.2.0 is blake2b256 as opposed to blake2s256.

This PR also re-enables the anchoring UI. The on-chain anchoring module is now live in both mainnet and on testnet.